### PR TITLE
fix create-channel

### DIFF
--- a/frontend/src/components/chat-creation-form.tsx
+++ b/frontend/src/components/chat-creation-form.tsx
@@ -90,7 +90,8 @@ const ChatCreationForm = ({ socket }: Props) => {
       const enteredIsPrivate = isPrivateInputRef.current.checked
       const enteredIsProtected = isProtectedInputRef.current.checked
       let enteredPassword = ''
-      if (enteredIsProtected == true) {
+      if (!enteredChannelName) return
+      if (enteredIsProtected == true && enteredIsPrivate == false) {
         enteredPassword = passwordInputRef.current.value
       }
       console.log(


### PR DESCRIPTION
close #61 

- priveteとprotectedを選んだ場合、パスワードを入力しても実際には反映されないようにしました（バグ回避のため）
- channnel名が空の場合は、何もせずに終了するようにしました

※他はenhancementにします

簡単な内容なので、1人確認したらそのままマージしてください